### PR TITLE
fix: pool_recycled

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ src/
 **Important Note:** OAuth tokens expire after one hour, but expiration is enforced only at login. Open connections remain active even if the token expires. However, any PostgreSQL command that requires authentication fails if the token has expired.  Read More: https://docs.databricks.com/aws/en/oltp/oauth
 
 **Automatic Token Refresh:**
-- 50 Minute token refresh with background async task that does not impact requests.
+- 50 Minute token refresh with background async task that does not impact requests
 - Guaranteed token refresh before expiry (safe for 1-hour token lifespans)
 - Optimized for high-traffic production applications
+- Pool connections are recycled every hour preventing expired tokens on long connections
 
 ## 📚 API Documentation
 

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -100,6 +100,7 @@ def init_engine():
             pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
             max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "10")),
             pool_timeout=int(os.getenv("DB_POOL_TIMEOUT", "30")),
+            pool_recycle=3600,  # Recycle connections every hour (before token expires)
             connect_args={
                 "command_timeout": int(os.getenv("DB_COMMAND_TIMEOUT", "10")),
                 "server_settings": {


### PR DESCRIPTION
Before: Long running connections would hold stale tokens. 

Now: Pool connections are recycled every hour preventing expired tokens on long connections